### PR TITLE
chore: update longhorn-images.txt for v1.11.x

### DIFF
--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,7 +1,7 @@
 dp.apps.rancher.io/containers/longhorn-engine:1.11.2-4.7
 dp.apps.rancher.io/containers/longhorn-manager:1.11.2-4.6
 dp.apps.rancher.io/containers/longhorn-ui:1.11.2-4.2
-dp.apps.rancher.io/containers/longhorn-instance-manager:1.11.2-4.9
+dp.apps.rancher.io/containers/longhorn-instance-manager:1.11.2-4.10
 dp.apps.rancher.io/containers/longhorn-share-manager:1.11.2-4.3
 dp.apps.rancher.io/containers/longhorn-backing-image-manager:1.11.2-4.6
 dp.apps.rancher.io/containers/rancher-support-bundle-kit:0.0.84-9.4


### PR DESCRIPTION
Auto-generated PR to update image versions for SUSE Storage v1.11.x.