### PR TITLE
chore: update longhorn-images.txt for v1.10.x

### DIFF
--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -1,8 +1,8 @@
-dp.apps.rancher.io/containers/longhorn-engine:1.10.4-9.8
+dp.apps.rancher.io/containers/longhorn-engine:1.10.4-9.9
 dp.apps.rancher.io/containers/longhorn-manager:1.10.4-9.9
-dp.apps.rancher.io/containers/longhorn-ui:1.10.4-9.2
-dp.apps.rancher.io/containers/longhorn-instance-manager:1.10.4-9.12
-dp.apps.rancher.io/containers/longhorn-share-manager:1.10.4-9.4
+dp.apps.rancher.io/containers/longhorn-ui:1.10.4-9.3
+dp.apps.rancher.io/containers/longhorn-instance-manager:1.10.4-9.15
+dp.apps.rancher.io/containers/longhorn-share-manager:1.10.4-9.5
 dp.apps.rancher.io/containers/longhorn-backing-image-manager:1.10.4-9.6
 dp.apps.rancher.io/containers/rancher-support-bundle-kit:0.0.87-10.3
 dp.apps.rancher.io/containers/kubernetes-csi-external-attacher:4.12.0-17.1


### PR DESCRIPTION
Auto-generated PR to update image versions for SUSE Storage v1.10.x.