### PR TITLE
chore: update longhorn-images.txt for v1.11.x

### DIFF
--- a/deploy/longhorn-images.txt
+++ b/deploy/longhorn-images.txt
@@ -6,7 +6,7 @@ dp.apps.rancher.io/containers/longhorn-share-manager:1.11.2-4.5
 dp.apps.rancher.io/containers/longhorn-backing-image-manager:1.11.2-4.9
 dp.apps.rancher.io/containers/rancher-support-bundle-kit:0.0.84-9.4
 dp.apps.rancher.io/containers/kubernetes-csi-external-attacher:4.11.0-13.2
-dp.apps.rancher.io/containers/kubernetes-csi-external-provisioner:5.3.0-17.1
+dp.apps.rancher.io/containers/kubernetes-csi-external-provisioner:5.3.0-17.2
 dp.apps.rancher.io/containers/kubernetes-csi-node-driver-registrar:2.16.0-13.2
 dp.apps.rancher.io/containers/kubernetes-csi-external-resizer:2.1.0-6.2
 dp.apps.rancher.io/containers/kubernetes-csi-external-snapshotter:8.5.0-13.2


### PR DESCRIPTION
Auto-generated PR to update image versions for SUSE Storage v1.11.x.